### PR TITLE
fix: extern distance func

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,3 +1,7 @@
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"
+
 [project]
 name = "spatial-graph"
 version = "0.0.1"
@@ -5,28 +9,19 @@ description = "A spatial graph datastructure for python."
 readme = "README.md"
 requires-python = ">=3.9"
 license = { text = "MIT" }
-authors = [
-    { email = "funkej@janelia.hhmi.org", name = "Jan Funke" },
-]
-dependencies = [
-  "witty>=v0.2.0",
-  "cheetah3",
-  "numpy",
-  "setuptools>=75.8.0",
-]
+authors = [{ email = "funkej@janelia.hhmi.org", name = "Jan Funke" }]
+dependencies = ["witty>=v0.2.0", "CT3", "numpy", "setuptools>=75.8.0"]
 
 [project.urls]
 homepage = "https://github.com/funkelab/spatial_graph"
 repository = "https://github.com/funkelab/spatial_graph"
 
 [project.optional-dependencies]
-dev = [
-    "pytest>=8.3.4",
-]
+dev = ["pytest>=8.3.4"]
 
 [tool.hatch.metadata]
 allow-direct-references = true
 
-[build-system]
-requires = ["hatchling"]
-build-backend = "hatchling.build"
+[tool.pytest.ini_options]
+testpaths = ["tests"]
+filterwarnings = ["ignore:'cgi' is deprecated:DeprecationWarning"]

--- a/spatial_graph/graph/graph.py
+++ b/spatial_graph/graph/graph.py
@@ -8,10 +8,15 @@ from ..dtypes import DType
 # Set platform-specific compile arguments
 if sys.platform == "win32":
     # Use /O2 for optimization and /std:c++20 for C++20
-    EXTRA_COMPILE_ARGS = ["/O2", "/std:c++20"]
+    EXTRA_COMPILE_ARGS = ["/O2", "/std:c++20", "/wd4101"]
 else:
     # -O3 for optimization and -std=c++20 for C++20
-    EXTRA_COMPILE_ARGS = ["-O3", "-std=c++20"]
+    EXTRA_COMPILE_ARGS = [
+        "-O3",
+        "-std=c++20",
+        "-Wno-unused-variable",
+        "-Wno-unreachable-code",
+    ]
 
 
 class Graph:

--- a/spatial_graph/rtree/line_rtree.py
+++ b/spatial_graph/rtree/line_rtree.py
@@ -91,7 +91,7 @@ inline coord_t point_segment_dist2(const coord_t point[], const coord_t start[],
     return length2(a);
 }
 
-inline coord_t distance(const coord_t point[], const struct rect *rect, const struct item_t item) {
+extern inline coord_t distance(const coord_t point[], const struct rect *rect, const struct item_t item) {
     coord_t start[DIMS];
     coord_t end[DIMS];
     for (int d = 0; d < DIMS; d++) {

--- a/spatial_graph/rtree/rtree.py
+++ b/spatial_graph/rtree/rtree.py
@@ -7,6 +7,10 @@ from pathlib import Path
 from ..dtypes import DType
 
 DEFINE_MACROS = [("RTREE_NOATOMICS", "1")] if sys.platform == "win32" else []
+if sys.platform == "win32":
+    EXTRA_COMPILE_ARGS = ["/O2"]
+else:
+    EXTRA_COMPILE_ARGS = ["-O3", "-Wno-unreachable-code"]
 
 
 class RTree:
@@ -100,7 +104,7 @@ class RTree:
                 src_dir / "src" / "rtree.c",
                 src_dir / "src" / "config.h",
             ],
-            extra_compile_args=["/O2" if sys.platform == "win32" else "-O3"],
+            extra_compile_args=EXTRA_COMPILE_ARGS,
             include_dirs=[str(src_dir)],
             language="c",
             quiet=True,


### PR DESCRIPTION
fixes #15 

can't say I completely understand what's going on here, but here's what I've gathered:

1. in the `c_distance_function` in `line_rtree.py` there are some functions that operate on coordinates of type `coord_t`, but use functions that assume float inputs (like `pow`).  This causes the compiler to make implicit type conversions between `int` and `double`... but only when `coord_t` was integer.
1. the `distance()` function itself is currently marked only as `inline coord_t distance`.
1. Depending on how different compilers handle that choice, they may or may not want to have a callable/linkable function instead of inlining.
1. `rtree.c` needs to call distance() when the `KNN_USE_EXACT_DISTANCE` flag is defined.
1. presumably, the default clang settings on a typical apple silicon are different than the ones on github actions... and if the compiler decides to inline the `distance` function, then it's not available for `rtree.c` and you get an error:

```
E ImportError: dlopen(/Users/talley/Library/Caches/cython/witty/_witty_module_d651d0d6eb5b4c8dfc8c306d41db0c67.cpython-312-darwin.so, 0x0002): symbol not found in flat namespace '_distance'
```

**solution**

declaring `extern inline coord_t distance` tells the compiler that distance must be available for linking and always generates a symbol for it.

-----

this PR also fixes #14 and further silences a few unnecessary compile-time warnings