### PR TITLE
refactor: add typing to dtype

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,6 +22,9 @@ repository = "https://github.com/funkelab/spatial_graph"
 [project.optional-dependencies]
 dev = [
     "pytest>=8.3.4",
+    "pre-commit",
+    "ruff",
+    "mypy",
 ]
 
 [tool.hatch.metadata]

--- a/spatial_graph/dtypes.py
+++ b/spatial_graph/dtypes.py
@@ -122,7 +122,7 @@ class DType:
                                 if an array type and array_index is given
         """
 
-        if self.is_array:
+        if self.size:
             if array_index:
                 return (
                     "{"

--- a/spatial_graph/dtypes.py
+++ b/spatial_graph/dtypes.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import re
 
 # Define valid base types

--- a/spatial_graph/dtypes.py
+++ b/spatial_graph/dtypes.py
@@ -19,8 +19,8 @@ VALID_BASE_TYPES = {
     "uint32": "uint32_t",
     "uint64": "uint64_t",
     # Platform-dependent types mapped to fixed-width equivalents
-    "int": "int32_t",  # Map generic int to standard 32-bit
-    "uint": "uint32_t",  # Map generic uint to standard 32-bit
+    "int": "int64_t",
+    "uint": "uint64_t",
 }
 
 # Regex pattern for dtype validation and extraction

--- a/tests/test_attributes.py
+++ b/tests/test_attributes.py
@@ -83,7 +83,7 @@ dtypes = ["float", "double", "int8", "uint8", "int16", "uint16"]
 
 
 @pytest.mark.parametrize("dtype", dtypes)
-def test_dtype(dtype):
+def test_attr_dtypes(dtype):
     graph = sg.SpatialGraph(
         ndims=3,
         node_dtype="uint64",

--- a/tests/test_dtype.py
+++ b/tests/test_dtype.py
@@ -1,0 +1,37 @@
+from __future__ import annotations
+from spatial_graph.dtypes import DType, VALID_BASE_TYPES
+import pytest
+
+
+@pytest.mark.parametrize("size", [None, 2])
+@pytest.mark.parametrize("base", VALID_BASE_TYPES.keys())
+def test_dtype(base: str, size: int | None) -> None:
+    if size is None:
+        dtype = DType(base)
+    else:
+        dtype = DType(f"{base}[{size}]")
+    assert dtype.base == base
+    assert dtype.size == size
+    assert dtype.is_array == (size is not None)
+    c_base = VALID_BASE_TYPES[base]
+    assert dtype.base_c_type == c_base
+    assert dtype.to_c_decl("test") == f"{c_base} test" + (f"[{size}]" if size else "")
+
+    assert dtype.to_pyxtype() == c_base + (f"[{size}]" if size else "")
+    assert dtype.to_pyxtype(use_memory_view=True) == c_base + (f"[::1]" if size else "")
+    assert dtype.to_pyxtype(add_dim=True) == c_base + ("[:, ::1]" if size else "[::1]")
+    assert dtype.to_pyxtype(use_memory_view=True, add_dim=True) == c_base + (
+        "[:, ::1]" if size else "[::1]"
+    )
+
+    if size == 2:
+        assert dtype.to_rvalue("test") == "{test[0], test[1]}"
+        assert dtype.to_rvalue("test", "i") == "{test[i, 0], test[i, 1]}"
+    elif size is None:
+        assert dtype.to_rvalue("test") == "test"
+        assert dtype.to_rvalue("test", "i") == "test[i]"
+
+
+def test_bad_dtype() -> None:
+    with pytest.raises(ValueError, match="Invalid dtype string"):
+        DType("not-a-valid-dtype")

--- a/tests/test_dtype.py
+++ b/tests/test_dtype.py
@@ -18,7 +18,7 @@ def test_dtype(base: str, size: int | None) -> None:
     assert dtype.to_c_decl("test") == f"{c_base} test" + (f"[{size}]" if size else "")
 
     assert dtype.to_pyxtype() == c_base + (f"[{size}]" if size else "")
-    assert dtype.to_pyxtype(use_memory_view=True) == c_base + (f"[::1]" if size else "")
+    assert dtype.to_pyxtype(use_memory_view=True) == c_base + ("[::1]" if size else "")
     assert dtype.to_pyxtype(add_dim=True) == c_base + ("[:, ::1]" if size else "[::1]")
     assert dtype.to_pyxtype(use_memory_view=True, add_dim=True) == c_base + (
         "[:, ::1]" if size else "[::1]"


### PR DESCRIPTION
makes the DType class a little stricter, validated immediately (rather than only when `base_c_type` is accessed), and adds typing