### PR TITLE
reduce test matrix

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,7 @@ build
 dist
 .vscode
 docs/_build/
+coverage.xml
 
 # remove me to enforce synchrony across development environments
 uv.lock

--- a/tests/test_graph.py
+++ b/tests/test_graph.py
@@ -3,17 +3,9 @@ import pytest
 
 import spatial_graph as sg
 
-node_dtypes = ["int8", "uint8", "int16", "uint16"]
-node_attr_dtypes = [
-    {"position": "double"},
-    {"position": "double[2]"},
-    {"position": "int[4]"},
-]
-edge_attr_dtypes = [
-    {},
-    {"score": "float64"},
-    {"score": "float64", "color": "uint8"},
-]
+node_dtypes = ["uint16"]
+node_attr_dtypes = [{"position": "double[2]"}]
+edge_attr_dtypes = [{"score": "float64", "color": "uint8"}]
 
 
 @pytest.mark.parametrize("node_dtype", node_dtypes)

--- a/tests/test_spatial_graph.py
+++ b/tests/test_spatial_graph.py
@@ -3,16 +3,9 @@ import pytest
 
 import spatial_graph as sg
 
-node_dtypes = ["int8", "uint8", "int16", "uint16"]
-node_attr_dtypes = [
-    {"position": "double[4]"},
-    {"position": "int[4]"},
-]
-edge_attr_dtypes = [
-    {},
-    {"score": "float64"},
-    {"score": "float64", "color": "uint8"},
-]
+node_dtypes = ["uint16"]
+node_attr_dtypes = [{"position": "double[4]"}]
+edge_attr_dtypes = [{"score": "float64", "color": "uint8"}]
 
 
 @pytest.mark.parametrize("node_dtype", node_dtypes)


### PR DESCRIPTION
should speed up CI without reducing test coverage.  can add back specific cases later if need be