### PR TITLE
Add CI workflow, Dockerfile, and update README for testing instructions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -74,3 +74,15 @@ jobs:
         with:
           generate_release_notes: true
           files: "./dist/*"
+
+  docker-test:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Build and test Docker image
+        run: |
+          docker build -t spatial_graph .
+          docker run --rm spatial_graph

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,38 @@
+FROM ubuntu:24.04
+
+ENV DEBIAN_FRONTEND=noninteractive \
+    MAMBA_ROOT_PREFIX=/opt/conda \
+    PATH=/opt/conda/bin:$PATH
+
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends \
+      git curl tar bzip2 ca-certificates && \
+    rm -rf /var/lib/apt/lists/*
+
+# auto-detect arch and grab the matching micromamba binary
+RUN set -eux; \
+    arch="$(uname -m)"; \
+    case "$arch" in \
+      x86_64)    url_arch=linux-64 ;; \
+      aarch64|arm64) url_arch=linux-aarch64 ;; \
+      ppc64le)   url_arch=linux-ppc64le ;; \
+      *)         echo "Unsupported arch: $arch"; exit 1 ;; \
+    esac; \
+    curl -Ls "https://micro.mamba.pm/api/micromamba/$url_arch/latest" \
+      | tar -xvj -C /usr/local/bin bin/micromamba; \
+    chmod +x /usr/local/bin/bin/micromamba; \
+    mv /usr/local/bin/bin/micromamba /usr/local/bin/micromamba; \
+    rmdir /usr/local/bin/bin
+    
+
+WORKDIR /app
+COPY . /app
+
+RUN micromamba create -y -n test-env -c conda-forge python=3.12 pip compilers
+RUN micromamba run -n test-env pip install -e . --group test
+
+SHELL ["micromamba", "run", "-n", "test-env", "/bin/bash", "-o", "pipefail", "-c"]
+
+
+# when you docker run, this will invoke pytest from inside test-env
+CMD ["micromamba", "run", "-n", "test-env", "pytest", "-q", "-x"]

--- a/README.md
+++ b/README.md
@@ -149,3 +149,14 @@ git push upstream --follow-tags
 ```
 
 This will trigger the CI workflow, which will build the package and upload it to PyPI.
+
+### Testing in a conda environment
+
+To simulate a naive user environment, with *no* assumptions made about the
+availability of a C/C++ compiler, you can run the included Dockerfile
+(where the key part of the conda env is the `compilers` package):
+
+```bash
+docker build -t spatial_graph .
+docker run --rm spatial_graph
+```

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,6 @@ build-backend = "hatchling.build"
 [tool.hatch.version]
 source = "vcs"
 
-
 [project]
 name = "spatial-graph"
 dynamic = ["version"]


### PR DESCRIPTION
this adds a Dockerfile that demonstrates the feasibility of running tests in a "naive" OS (via docker) by using conda to install the `compilers` package... followed by running tests the usual way