### PR TITLE
Improve type hints for SpatialGraph

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -55,6 +55,8 @@ repository = "https://github.com/funkelab/spatial_graph"
 [tool.ruff]
 target-version = "py39"
 line-length = 88
+fix = true
+unsafe-fixes = true
 
 [tool.ruff.lint]
 select = [

--- a/src/spatial_graph/graph/cgraph.pyi
+++ b/src/spatial_graph/graph/cgraph.pyi
@@ -210,9 +210,11 @@ class UnDirectedCGraph(CGraph):
             Array of neighbor counts for each node in the input array.
         """
     @overload
-    def edges(self, node: Any, data: Literal[True]) -> Iterator[tuple[tuple, Any]]: ...
+    def edges(
+        self, node: Any = ..., data: Literal[True] = ...
+    ) -> Iterator[tuple[tuple, Any]]: ...
     @overload
-    def edges(self, node: Any, data: Literal[False]) -> Iterator[tuple]:
+    def edges(self, node: Any = ..., data: Literal[False] = ...) -> Iterator[tuple]:
         """Iterate over edges in the graph.
 
         For undirected graphs, each edge is yielded only once with nodes
@@ -289,7 +291,7 @@ class DirectedCGraph(CGraph):
         """
     @overload
     def in_edges(
-        self, node: Any = None, *, data: Literal[True]
+        self, node: Any = None, data: Literal[True] = ...
     ) -> Iterator[tuple[tuple, Any]]: ...
     @overload
     def in_edges(self, node: Any, data: Literal[False] = ...) -> Iterator[tuple]:
@@ -334,10 +336,10 @@ class DirectedCGraph(CGraph):
         """
     @overload
     def out_edges(
-        self, node: Any, data: Literal[True]
+        self, node: Any = None, data: Literal[True] = ...
     ) -> Iterator[tuple[tuple, Any]]: ...
     @overload
-    def out_edges(self, node: Any, data: Literal[False]) -> Iterator[tuple]:
+    def out_edges(self, node: Any, data: Literal[False] = ...) -> Iterator[tuple]:
         """Iterate over outgoing edges from a node.
 
         Only edges directed away from the specified node are yielded.

--- a/src/spatial_graph/graph/cgraph.pyi
+++ b/src/spatial_graph/graph/cgraph.pyi
@@ -7,17 +7,79 @@ class CGraph:
     def add_node(self, node: Any, *data: Any, **kwargs: Any) -> int:
         """Add a single node to the graph.
 
-        Names/number of args kwargs must match the `node_attr_dtypes`.
+        Parameters
+        ----------
+        node : Any
+            The node identifier to add to the graph.
+        *data : Any
+            Positional arguments for node attributes. Names/number of args
+            must match the `node_attr_dtypes`.
+        **kwargs : Any
+            Keyword arguments for node attributes. Names/number of kwargs
+            must match the `node_attr_dtypes`.
+
+        Returns
+        -------
+        int
+            Number of nodes added (1 if successful, 0 if node already exists).
+
+        Notes
+        -----
+        The node attributes provided via *data and **kwargs must match the
+        data types and names specified in `node_attr_dtypes` when the graph
+        was created.
         """
     def add_nodes(self, nodes: np.ndarray, *data: Any, **kwargs: Any) -> int:
         """Add multiple nodes to the graph.
 
-        Names/number of args kwargs must match the `node_attr_dtypes`.
+        Parameters
+        ----------
+        nodes : np.ndarray
+            Array of node identifiers to add to the graph.
+        *data : Any
+            Positional arguments for node attributes. Each argument should be
+            an array with length matching `nodes`. Names/number of args must
+            match the `node_attr_dtypes`.
+        **kwargs : Any
+            Keyword arguments for node attributes. Each argument should be
+            an array with length matching `nodes`. Names/number of kwargs
+            must match the `node_attr_dtypes`.
+
+        Returns
+        -------
+        int
+            Number of nodes successfully added.
+
+        Notes
+        -----
+        Node attributes provided via *data and **kwargs must match the
+        data types and names specified in `node_attr_dtypes`. Each attribute
+        array must have the same length as the `nodes` array.
         """
     def add_edge(self, edge: np.ndarray, *args: Any, **kwargs: Any) -> int:
         """Add an edge to the graph.
 
-        Names/number of args kwargs must match the `edge_attr_dtypes`.
+        Parameters
+        ----------
+        edge : np.ndarray
+            Array of length 2 containing [source_node, target_node].
+        *args : Any
+            Positional arguments for edge attributes. Names/number of args
+            must match the `edge_attr_dtypes`.
+        **kwargs : Any
+            Keyword arguments for edge attributes. Names/number of kwargs
+            must match the `edge_attr_dtypes`.
+
+        Returns
+        -------
+        int
+            Number of edges added (1 if successful, 0 if edge already exists).
+
+        Notes
+        -----
+        The edge attributes provided via *args and **kwargs must match the
+        data types and names specified in `edge_attr_dtypes` when the graph
+        was created.
         """
 
     def add_edges(
@@ -25,30 +87,316 @@ class CGraph:
     ) -> int:
         """Add multiple edges to the graph.
 
-        Edges must be 2D and names/number of args kwargs must match the
-        `edge_attr_dtypes`.
+        Parameters
+        ----------
+        edges : np.ndarray
+            2D array of shape (n_edges, 2) where each row contains
+            [source_node, target_node].
+        *args : np.ndarray
+            Positional arguments for edge attributes. Each argument should be
+            an array with length matching the number of edges. Names/number
+            of args must match the `edge_attr_dtypes`.
+        **kwargs : np.ndarray
+            Keyword arguments for edge attributes. Each argument should be
+            an array with length matching the number of edges. Names/number
+            of kwargs must match the `edge_attr_dtypes`.
+
+        Returns
+        -------
+        int
+            Number of edges successfully added.
+
+        Notes
+        -----
+        Edge attributes provided via *args and **kwargs must match the
+        data types and names specified in `edge_attr_dtypes`. Each attribute
+        array must have the same length as the number of edges.
         """
 
     def nodes(self) -> np.ndarray:
-        """Get all node IDs."""
-    def remove_node(self, node: Any) -> None: ...
-    def remove_nodes(self, nodes: np.ndarray) -> None: ...
-    def nodes_data(
-        self, nodes: np.ndarray | None = None
-    ) -> Iterator[tuple[Any, Any]]: ...
-    def edges_data(self, us: np.ndarray, vs: np.ndarray) -> Iterator: ...
-    def num_edges(self) -> int: ...
+        """Get all node IDs in the graph.
+
+        Returns
+        -------
+        np.ndarray
+            Array containing all node identifiers in the graph, ordered
+            by insertion order (earliest added first).
+
+        Notes
+        -----
+        The returned array is a copy and modifications will not affect
+        the graph structure.
+        """
+    def remove_node(self, node: Any) -> None:
+        """Remove a single node from the graph.
+
+        Parameters
+        ----------
+        node : Any
+            The node identifier to remove from the graph.
+
+        Notes
+        -----
+        Removing a node will also remove all edges incident to that node.
+        """
+    def remove_nodes(self, nodes: np.ndarray) -> None:
+        """Remove multiple nodes from the graph.
+
+        Parameters
+        ----------
+        nodes : np.ndarray
+            Array of node identifiers to remove from the graph.
+
+        Notes
+        -----
+        Removing nodes will also remove all edges incident to those nodes.
+        """
+    def nodes_data(self, nodes: np.ndarray | None = None) -> Iterator[tuple[Any, Any]]:
+        """Iterate over nodes and their associated data.
+
+        Parameters
+        ----------
+        nodes : np.ndarray, optional
+            Array of specific node identifiers to iterate over. If None,
+            iterates over all nodes in the graph.
+
+        Yields
+        ------
+        tuple[Any, Any]
+            Tuples of (node_id, node_data) where node_data is a view object
+            providing access to the node's attributes.
+
+        Notes
+        -----
+        The node_data object provides access to node attributes as defined
+        by the `node_attr_dtypes` when the graph was created.
+        """
+    def edges_data(self, us: np.ndarray, vs: np.ndarray) -> Iterator:
+        """Iterate over edge data for specified edges.
+
+        Parameters
+        ----------
+        us : np.ndarray
+            Array of source node identifiers.
+        vs : np.ndarray
+            Array of target node identifiers.
+
+        Yields
+        ------
+        Any
+            Edge data view objects providing access to edge attributes
+            for each edge (us[i], vs[i]).
+
+        Notes
+        -----
+        The arrays `us` and `vs` must have the same length. The edge data
+        objects provide access to edge attributes as defined by the
+        `edge_attr_dtypes` when the graph was created.
+        """
+    def num_edges(self) -> int:
+        """Get the total number of edges in the graph.
+
+        Returns
+        -------
+        int
+            The number of edges in the graph.
+        """
+    def __len__(self) -> int:
+        """Return the number of nodes in the graph.
+
+        Returns
+        -------
+        int
+            The number of nodes in the graph.
+        """
 
 class UnDirectedCGraph(CGraph):
-    def count_neighbors(self, nodes: np.ndarray) -> int: ...
-    def edges(self, node: Any = None, data: bool = False) -> Iterator: ...
+    def count_neighbors(self, nodes: np.ndarray) -> int:
+        """Count the number of neighbors for each node.
+
+        Parameters
+        ----------
+        nodes : np.ndarray
+            Array of node identifiers to count neighbors for.
+
+        Returns
+        -------
+        int
+            Array of neighbor counts for each node in the input array.
+
+        Notes
+        -----
+        For undirected graphs, this counts all adjacent nodes regardless
+        of edge direction since edges are bidirectional.
+        """
+    def edges(self, node: Any = None, data: bool = False) -> Iterator:
+        """Iterate over edges in the graph.
+
+        Parameters
+        ----------
+        node : Any, optional
+            If provided, only iterate over edges incident to this node.
+            If None, iterate over all edges in the graph.
+        data : bool, default False
+            If True, yield (edge, edge_data) tuples. If False, yield
+            only edge tuples.
+
+        Yields
+        ------
+        tuple or tuple[tuple, Any]
+            If data=False: tuples of (node1, node2) representing edges.
+            If data=True: tuples of ((node1, node2), edge_data) where
+            edge_data provides access to edge attributes.
+
+        Notes
+        -----
+        For undirected graphs, each edge is yielded only once with nodes
+        ordered such that node1 < node2 to avoid duplicates.
+        """
     def edges_by_nodes(self, nodes: np.ndarray) -> np.ndarray:
-        """Same as edges, for fast access to edges incident to an array of nodes."""
+        """Get all edges incident to the specified nodes.
+
+        Parameters
+        ----------
+        nodes : np.ndarray
+            Array of node identifiers to find incident edges for.
+
+        Returns
+        -------
+        np.ndarray
+            2D array of shape (n_edges, 2) where each row contains
+            [node1, node2] representing an edge. For undirected graphs,
+            node1 <= node2.
+
+        Notes
+        -----
+        This method provides fast access to edges incident to an array
+        of nodes. Note that edges between nodes in the input array will
+        be reported multiple times (once for each incident node).
+        """
 
 class DirectedCGraph(CGraph):
-    def count_in_neighbors(self, nodes: np.ndarray) -> int: ...
-    def count_out_neighbors(self, nodes: np.ndarray) -> int: ...
-    def in_edges(self, node: Any, data: bool): ...
-    def in_edges_by_nodes(self, nodes: np.ndarray) -> np.ndarray: ...
-    def out_edges(self, node: Any, data: bool): ...
-    def out_edges_by_nodes(self, nodes: np.ndarray) -> np.ndarray: ...
+    def count_in_neighbors(self, nodes: np.ndarray) -> int:
+        """Count the number of incoming neighbors for each node.
+
+        Parameters
+        ----------
+        nodes : np.ndarray
+            Array of node identifiers to count incoming neighbors for.
+
+        Returns
+        -------
+        int
+            Array of incoming neighbor counts for each node in the input array.
+
+        Notes
+        -----
+        For directed graphs, this counts only nodes that have edges pointing
+        to the specified nodes (i.e., predecessors).
+        """
+    def count_out_neighbors(self, nodes: np.ndarray) -> int:
+        """Count the number of outgoing neighbors for each node.
+
+        Parameters
+        ----------
+        nodes : np.ndarray
+            Array of node identifiers to count outgoing neighbors for.
+
+        Returns
+        -------
+        int
+            Array of outgoing neighbor counts for each node in the input array.
+
+        Notes
+        -----
+        For directed graphs, this counts only nodes that the specified nodes
+        have edges pointing to (i.e., successors).
+        """
+    def in_edges(self, node: Any, data: bool):
+        """Iterate over incoming edges to a node.
+
+        Parameters
+        ----------
+        node : Any
+            The target node to find incoming edges for.
+        data : bool
+            If True, yield (edge, edge_data) tuples. If False, yield
+            only edge tuples.
+
+        Yields
+        ------
+        tuple or tuple[tuple, Any]
+            If data=False: tuples of (source_node, target_node) representing
+            incoming edges where target_node is the specified node.
+            If data=True: tuples of ((source_node, target_node), edge_data)
+            where edge_data provides access to edge attributes.
+
+        Notes
+        -----
+        Only edges directed toward the specified node are yielded.
+        """
+    def in_edges_by_nodes(self, nodes: np.ndarray) -> np.ndarray:
+        """Get all incoming edges to the specified nodes.
+
+        Parameters
+        ----------
+        nodes : np.ndarray
+            Array of node identifiers to find incoming edges for.
+
+        Returns
+        -------
+        np.ndarray
+            2D array of shape (n_edges, 2) where each row contains
+            [source_node, target_node] representing an incoming edge
+            to one of the specified nodes.
+
+        Notes
+        -----
+        This method provides fast access to incoming edges for an array
+        of nodes. Edges between nodes in the input array will be reported
+        multiple times if both source and target are in the array.
+        """
+    def out_edges(self, node: Any, data: bool):
+        """Iterate over outgoing edges from a node.
+
+        Parameters
+        ----------
+        node : Any
+            The source node to find outgoing edges for.
+        data : bool
+            If True, yield (edge, edge_data) tuples. If False, yield
+            only edge tuples.
+
+        Yields
+        ------
+        tuple or tuple[tuple, Any]
+            If data=False: tuples of (source_node, target_node) representing
+            outgoing edges where source_node is the specified node.
+            If data=True: tuples of ((source_node, target_node), edge_data)
+            where edge_data provides access to edge attributes.
+
+        Notes
+        -----
+        Only edges directed away from the specified node are yielded.
+        """
+    def out_edges_by_nodes(self, nodes: np.ndarray) -> np.ndarray:
+        """Get all outgoing edges from the specified nodes.
+
+        Parameters
+        ----------
+        nodes : np.ndarray
+            Array of node identifiers to find outgoing edges for.
+
+        Returns
+        -------
+        np.ndarray
+            2D array of shape (n_edges, 2) where each row contains
+            [source_node, target_node] representing an outgoing edge
+            from one of the specified nodes.
+
+        Notes
+        -----
+        This method provides fast access to outgoing edges for an array
+        of nodes. Edges between nodes in the input array will be reported
+        multiple times if both source and target are in the array.
+        """

--- a/src/spatial_graph/graph/cgraph.pyi
+++ b/src/spatial_graph/graph/cgraph.pyi
@@ -1,0 +1,54 @@
+from collections.abc import Iterator
+from typing import Any
+
+import numpy as np
+
+class CGraph:
+    def add_node(self, node: Any, *data: Any, **kwargs: Any) -> int:
+        """Add a single node to the graph.
+
+        Names/number of args kwargs must match the `node_attr_dtypes`.
+        """
+    def add_nodes(self, nodes: np.ndarray, *data: Any, **kwargs: Any) -> int:
+        """Add multiple nodes to the graph.
+
+        Names/number of args kwargs must match the `node_attr_dtypes`.
+        """
+    def add_edge(self, edge: np.ndarray, *args: Any, **kwargs: Any) -> int:
+        """Add an edge to the graph.
+
+        Names/number of args kwargs must match the `edge_attr_dtypes`.
+        """
+
+    def add_edges(
+        self, edges: np.ndarray, *args: np.ndarray, **kwargs: np.ndarray
+    ) -> int:
+        """Add multiple edges to the graph.
+
+        Edges must be 2D and names/number of args kwargs must match the
+        `edge_attr_dtypes`.
+        """
+
+    def nodes(self) -> np.ndarray:
+        """Get all node IDs."""
+    def remove_node(self, node: Any) -> None: ...
+    def remove_nodes(self, nodes: np.ndarray) -> None: ...
+    def nodes_data(
+        self, nodes: np.ndarray | None = None
+    ) -> Iterator[tuple[Any, Any]]: ...
+    def edges_data(self, us: np.ndarray, vs: np.ndarray) -> Iterator: ...
+    def num_edges(self) -> int: ...
+
+class UnDirectedCGraph(CGraph):
+    def count_neighbors(self, nodes: np.ndarray) -> int: ...
+    def edges(self, node: Any = None, data: bool = False) -> Iterator: ...
+    def edges_by_nodes(self, nodes: np.ndarray) -> np.ndarray:
+        """Same as edges, for fast access to edges incident to an array of nodes."""
+
+class DirectedCGraph(CGraph):
+    def count_in_neighbors(self, nodes: np.ndarray) -> int: ...
+    def count_out_neighbors(self, nodes: np.ndarray) -> int: ...
+    def in_edges(self, node: Any, data: bool): ...
+    def in_edges_by_nodes(self, nodes: np.ndarray) -> np.ndarray: ...
+    def out_edges(self, node: Any, data: bool): ...
+    def out_edges_by_nodes(self, nodes: np.ndarray) -> np.ndarray: ...

--- a/src/spatial_graph/graph/cgraph.pyi
+++ b/src/spatial_graph/graph/cgraph.pyi
@@ -193,8 +193,8 @@ class CGraph:
         """
 
 class UnDirectedCGraph(CGraph):
-    def count_neighbors(self, nodes: np.ndarray) -> np.ndarray:
-        """Count the number of neighbors for each node.
+    def num_neighbors(self, nodes: np.ndarray) -> np.ndarray:
+        """Return the number of neighbors for each node.
 
         For undirected graphs, this counts all adjacent nodes regardless
         of edge direction since edges are bidirectional.
@@ -257,8 +257,8 @@ class UnDirectedCGraph(CGraph):
         """
 
 class DirectedCGraph(CGraph):
-    def count_in_neighbors(self, nodes: np.ndarray) -> np.ndarray:
-        """Count the number of incoming neighbors for each node.
+    def num_in_neighbors(self, nodes: np.ndarray) -> np.ndarray:
+        """Return the number of incoming neighbors for each node.
 
         This counts only nodes that have edges pointing to the specified nodes
         (i.e., predecessors).
@@ -273,8 +273,8 @@ class DirectedCGraph(CGraph):
         np.ndarray
             Array of incoming neighbor counts for each node in the input array.
         """
-    def count_out_neighbors(self, nodes: np.ndarray) -> np.ndarray:
-        """Count the number of outgoing neighbors for each node.
+    def num_out_neighbors(self, nodes: np.ndarray) -> np.ndarray:
+        """Return the number of outgoing neighbors for each node.
 
         This counts only nodes that the specified nodes
         have edges pointing to (i.e., successors).

--- a/src/spatial_graph/graph/cgraph.pyi
+++ b/src/spatial_graph/graph/cgraph.pyi
@@ -7,6 +7,10 @@ class CGraph:
     def add_node(self, node: Any, *data: Any, **kwargs: Any) -> int:
         """Add a single node to the graph.
 
+        The node attributes provided via *data and **kwargs must match the
+        data types and names specified in `node_attr_dtypes` when the graph
+        was created.
+
         Parameters
         ----------
         node : Any
@@ -22,15 +26,13 @@ class CGraph:
         -------
         int
             Number of nodes added (1 if successful, 0 if node already exists).
-
-        Notes
-        -----
-        The node attributes provided via *data and **kwargs must match the
-        data types and names specified in `node_attr_dtypes` when the graph
-        was created.
         """
     def add_nodes(self, nodes: np.ndarray, *data: Any, **kwargs: Any) -> int:
         """Add multiple nodes to the graph.
+
+        Node attributes provided via *data and **kwargs must match the
+        data types and names specified in `node_attr_dtypes`. Each attribute
+        array must have the same length as the `nodes` array.
 
         Parameters
         ----------
@@ -49,15 +51,13 @@ class CGraph:
         -------
         int
             Number of nodes successfully added.
-
-        Notes
-        -----
-        Node attributes provided via *data and **kwargs must match the
-        data types and names specified in `node_attr_dtypes`. Each attribute
-        array must have the same length as the `nodes` array.
         """
     def add_edge(self, edge: np.ndarray, *args: Any, **kwargs: Any) -> int:
         """Add an edge to the graph.
+
+        The edge attributes provided via *args and **kwargs must match the
+        data types and names specified in `edge_attr_dtypes` when the graph
+        was created.
 
         Parameters
         ----------
@@ -74,18 +74,16 @@ class CGraph:
         -------
         int
             Number of edges added (1 if successful, 0 if edge already exists).
-
-        Notes
-        -----
-        The edge attributes provided via *args and **kwargs must match the
-        data types and names specified in `edge_attr_dtypes` when the graph
-        was created.
         """
 
     def add_edges(
         self, edges: np.ndarray, *args: np.ndarray, **kwargs: np.ndarray
     ) -> int:
         """Add multiple edges to the graph.
+
+        Edge attributes provided via *args and **kwargs must match the
+        data types and names specified in `edge_attr_dtypes`. Each attribute
+        array must have the same length as the number of edges.
 
         Parameters
         ----------
@@ -105,54 +103,45 @@ class CGraph:
         -------
         int
             Number of edges successfully added.
-
-        Notes
-        -----
-        Edge attributes provided via *args and **kwargs must match the
-        data types and names specified in `edge_attr_dtypes`. Each attribute
-        array must have the same length as the number of edges.
         """
 
     def nodes(self) -> np.ndarray:
         """Get all node IDs in the graph.
+
+        The returned array is a copy and modifications will not affect
+        the graph structure.
 
         Returns
         -------
         np.ndarray
             Array containing all node identifiers in the graph, ordered
             by insertion order (earliest added first).
-
-        Notes
-        -----
-        The returned array is a copy and modifications will not affect
-        the graph structure.
         """
     def remove_node(self, node: Any) -> None:
         """Remove a single node from the graph.
+
+        Removing a node will also remove all edges incident to that node.
 
         Parameters
         ----------
         node : Any
             The node identifier to remove from the graph.
-
-        Notes
-        -----
-        Removing a node will also remove all edges incident to that node.
         """
     def remove_nodes(self, nodes: np.ndarray) -> None:
         """Remove multiple nodes from the graph.
+
+        Removing nodes will also remove all edges incident to those nodes.
 
         Parameters
         ----------
         nodes : np.ndarray
             Array of node identifiers to remove from the graph.
-
-        Notes
-        -----
-        Removing nodes will also remove all edges incident to those nodes.
         """
     def nodes_data(self, nodes: np.ndarray | None = None) -> Iterator[tuple[Any, Any]]:
         """Iterate over nodes and their associated data.
+
+        The node_data object provides access to node attributes as defined
+        by the `node_attr_dtypes` when the graph was created.
 
         Parameters
         ----------
@@ -165,14 +154,13 @@ class CGraph:
         tuple[Any, Any]
             Tuples of (node_id, node_data) where node_data is a view object
             providing access to the node's attributes.
-
-        Notes
-        -----
-        The node_data object provides access to node attributes as defined
-        by the `node_attr_dtypes` when the graph was created.
         """
     def edges_data(self, us: np.ndarray, vs: np.ndarray) -> Iterator:
         """Iterate over edge data for specified edges.
+
+        The arrays `us` and `vs` must have the same length. The edge data
+        objects provide access to edge attributes as defined by the
+        `edge_attr_dtypes` when the graph was created.
 
         Parameters
         ----------
@@ -186,12 +174,6 @@ class CGraph:
         Any
             Edge data view objects providing access to edge attributes
             for each edge (us[i], vs[i]).
-
-        Notes
-        -----
-        The arrays `us` and `vs` must have the same length. The edge data
-        objects provide access to edge attributes as defined by the
-        `edge_attr_dtypes` when the graph was created.
         """
     def num_edges(self) -> int:
         """Get the total number of edges in the graph.
@@ -214,6 +196,9 @@ class UnDirectedCGraph(CGraph):
     def count_neighbors(self, nodes: np.ndarray) -> int:
         """Count the number of neighbors for each node.
 
+        For undirected graphs, this counts all adjacent nodes regardless
+        of edge direction since edges are bidirectional.
+
         Parameters
         ----------
         nodes : np.ndarray
@@ -223,14 +208,12 @@ class UnDirectedCGraph(CGraph):
         -------
         int
             Array of neighbor counts for each node in the input array.
-
-        Notes
-        -----
-        For undirected graphs, this counts all adjacent nodes regardless
-        of edge direction since edges are bidirectional.
         """
     def edges(self, node: Any = None, data: bool = False) -> Iterator:
         """Iterate over edges in the graph.
+
+        For undirected graphs, each edge is yielded only once with nodes
+        ordered such that node1 < node2 to avoid duplicates.
 
         Parameters
         ----------
@@ -247,14 +230,13 @@ class UnDirectedCGraph(CGraph):
             If data=False: tuples of (node1, node2) representing edges.
             If data=True: tuples of ((node1, node2), edge_data) where
             edge_data provides access to edge attributes.
-
-        Notes
-        -----
-        For undirected graphs, each edge is yielded only once with nodes
-        ordered such that node1 < node2 to avoid duplicates.
         """
     def edges_by_nodes(self, nodes: np.ndarray) -> np.ndarray:
         """Get all edges incident to the specified nodes.
+
+        This method provides fast access to edges incident to an array
+        of nodes. Note that edges between nodes in the input array will
+        be reported multiple times (once for each incident node).
 
         Parameters
         ----------
@@ -270,9 +252,7 @@ class UnDirectedCGraph(CGraph):
 
         Notes
         -----
-        This method provides fast access to edges incident to an array
-        of nodes. Note that edges between nodes in the input array will
-        be reported multiple times (once for each incident node).
+
         """
 
 class DirectedCGraph(CGraph):

--- a/src/spatial_graph/graph/wrapper_template.pyx
+++ b/src/spatial_graph/graph/wrapper_template.pyx
@@ -618,7 +618,7 @@ cdef class Graph:
     %set $prefixes=[""]
     %end if
     %for prefix in $prefixes
-    def count_${prefix}neighbors(self, NodeType[:] nodes):
+    def num_${prefix}neighbors(self, NodeType[:] nodes):
         num_nodes = len(nodes)
         cdef int[:] counts = view.array(
             shape=(num_nodes,),

--- a/src/spatial_graph/graph/wrapper_template.pyx
+++ b/src/spatial_graph/graph/wrapper_template.pyx
@@ -647,7 +647,7 @@ cdef class Graph:
                 inc(it)
 
     def _num_${prefix}edges(self, NodeType[::1] nodes):
-        return np.sum(self.count_${prefix}neighbors(nodes))
+        return np.sum(self.num_${prefix}neighbors(nodes))
     %end for
 
     def __len__(self):

--- a/src/spatial_graph/rtree/wrapper_template.pyx
+++ b/src/spatial_graph/rtree/wrapper_template.pyx
@@ -345,8 +345,8 @@ cdef class RTree:
                 convert_pyx_to_c_item(&pyx_items[i], &bb_mins[i, 0], &bb_maxs[i, 0]))
             if num_deleted == -1:
                 raise RuntimeError("RTree delete ran out of memory.")
-            if num_deleted == 0:
-                print(f"Item {pyx_items[i]} not deleted!")
+            # if num_deleted == 0:
+                # print(f"Item {pyx_items[i]} not deleted!")
             total_deleted += num_deleted
 
         return total_deleted

--- a/tests/test_graph.py
+++ b/tests/test_graph.py
@@ -44,8 +44,8 @@ def test_operations(directed):
         assert graph.num_edges() == len(nodes) ** 2 - len(nodes)
 
         for node in nodes:
-            in_neighbors = graph.count_in_neighbors(np.array([node], dtype="uint64"))
-            out_neighbors = graph.count_in_neighbors(np.array([node], dtype="uint64"))
+            in_neighbors = graph.num_in_neighbors(np.array([node], dtype="uint64"))
+            out_neighbors = graph.num_in_neighbors(np.array([node], dtype="uint64"))
             assert len(in_neighbors) == 1
             assert len(out_neighbors) == 1
             assert in_neighbors[0] == len(nodes) - 1
@@ -61,7 +61,7 @@ def test_operations(directed):
         assert graph.num_edges() == (len(nodes) ** 2 - len(nodes)) / 2
 
         for node in nodes:
-            neighbors = graph.count_neighbors(np.array([node], dtype="uint64"))
+            neighbors = graph.num_neighbors(np.array([node], dtype="uint64"))
             assert len(neighbors) == 1
             assert neighbors[0] == len(nodes) - 1
 


### PR DESCRIPTION
alternative to #18 

this adds a type stub that indicates the methods added by the base cython graph class.  I have some thoughts on how to improve this in the future (perhaps turning `Graph` itself into a factory function rather than a base class...)  but will do that later