### PR TITLE
fix: _compile_tree to use depends_on for rtree.c instead of source_files

### DIFF
--- a/src/spatial_graph/_rtree/rtree.py
+++ b/src/spatial_graph/_rtree/rtree.py
@@ -48,10 +48,8 @@ def _compile_tree(
     wrapper = _build_wrapper(cls, item_dtype, coord_dtype, dims)
     module = witty.compile_cython(
         wrapper,
-        source_files=[
-            SRC_DIR / "src" / "rtree.c",
-        ],
         depends_on=[
+            SRC_DIR / "src" / "rtree.c",
             SRC_DIR / "src" / "rtree.h",
             SRC_DIR / "src" / "config.h",
         ],


### PR DESCRIPTION
fixing the broken tests

`SRC_DIR / "src" / "rtree.c"`

is `#included` and doesn't need to be listed as a compilation/link target.
